### PR TITLE
expose the getIssueLabels method

### DIFF
--- a/metahub.js
+++ b/metahub.js
@@ -180,6 +180,14 @@ Metahub.prototype.getIssue = function (number) {
     then(stripUrl);
 };
 
+Metahub.prototype.getIssueLabels = function (number) {
+  var msg = _.defaults({
+    number: number
+  }, this.config.msg);
+  return this.rest.issues.getIssueLabels(msg).
+    then(stripUrl);
+};
+
 Metahub.prototype.getContributors = function () {
   return this.rest.repos.getContributors(this.config.msg).
     then(stripUrl);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "q": "~0.9.6",
     "lodash": "~1.3.1",
-    "github": "~0.1.10",
+    "github": "~0.2.4",
     "express": "~3.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Because labels are not part of the  pull_request payload, let's expose a way to retrieve them if required
